### PR TITLE
Changelog as release notes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,11 @@
+## Version  1.1.1
+### Bugfixes
+- Added scroll to Certificate Manager on small screen #19
+
+## Version  1.1.0
+### Features
+- Added new screen Certificate Manager
+
+## Version  1.0.0
+### Updates
+- Updated to React Bootstrap 4

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "leaflet": "^1.2.0",
     "mcc-mnc-list": "^1.0.82",
     "nedb": "^1.8.0",
-    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^3.1.0",
+    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:3.3.0",
     "react-chartjs-2": "^2.5.6",
     "react-leaflet": "^1.5.0",
     "react-rangeslider": "^2.2.0"


### PR DESCRIPTION
This is part of [NCP-2820](https://projecttools.nordicsemi.no/jira/browse/NCP-2820). The whole concept is described there.

This changes two things:
- It adds a `Changelog.md` which contains all entries that were previously in the GitHub releases.
- It references devdep 3.3 so that future releases of this app will also upload the `Changelog.md` to developer.nordicsemi.com.

Because this changes depends on the release of devdep 3.3, this PR is created as a draft PR and  will be marked as being ready later when NordicSemiconductor/pc-nrfconnect-devdep#26 is merged and devdep 3.3 is released.