### PR TITLE
Harden against new serialport version

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -50,6 +50,9 @@ const platform = process.platform.slice(0, 3);
 
 /* eslint react/prop-types: 0 */
 
+// Prefer to use the serialport 8 property or fall back to the serialport 7 property
+const portPath = serialPort => serialPort.path || serialPort.comName;
+
 /**
  * Pick the serialport that should belong to the modem on PCA10090
  * @param {Array<device>} serialports array of device-lister serialport objects
@@ -67,7 +70,7 @@ function pickSerialPort(serialports) {
             return serialports.find(s => (/-if00$/.test(s.pnpId)));
         case 'dar':
             // this doesn't work, but with fixDevices() can't happen
-            return serialports.find(s => (/1$/.test(s.comName)));
+            return serialports.find(s => (/1$/.test(portPath(s))));
         default:
     }
     return undefined;
@@ -181,7 +184,7 @@ export default {
 
             const serialport = pickSerialPort(serialports);
             if (serialport) {
-                store.dispatch(ModemActions.open(serialport));
+                store.dispatch(ModemActions.open(portPath(serialport)));
             }
         }
         if (action.type === 'DEVICE_DESELECTED') {

--- a/lib/actions/modemActions.js
+++ b/lib/actions/modemActions.js
@@ -402,7 +402,7 @@ export function close() {
     };
 }
 
-export function open(serialPort) {
+export function open(portPath) {
     return async () => {
         await dispatch(close());
         dispatch(clearChart());
@@ -412,7 +412,7 @@ export function open(serialPort) {
             dispatch(terminalActions.printTX(data));
         }
 
-        port = new ModemPort(serialPort.comName, { writeCallback });
+        port = new ModemPort(portPath, { writeCallback });
 
         port.on('event', unsolicitedHandler);
         port.on('error', err => {
@@ -438,7 +438,7 @@ export function open(serialPort) {
             return;
         }
         logger.info('Modem port is opened');
-        dispatch(modemOpenedAction(serialPort.comName));
+        dispatch(modemOpenedAction(portPath));
 
         if (getState().app.ui.autoRequests) {
             try {


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

This enables the app to run with either serialport 7 (which had `comName` as a property) or serialport 8 (which moved to the property `path` and warns when still using comName).