### PR TITLE
Add help text to PSK input

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 1.1.4
+### Updates
+- Added help text to pre-shared key input field #37
+
 ## Version 1.1.3
 ### Bugfixes
 - Fixed broken build

--- a/lib/components/CertificateManagerView.jsx
+++ b/lib/components/CertificateManagerView.jsx
@@ -55,6 +55,7 @@ const NRF_CLOUD_TAG = 16842753;
 
 const FormGroupWithCheckbox = ({
     controlId, controlProps, label, value, set, clearLabel, clear, setClear,
+    subText,
 }) => (
     <Form.Group as={Row} controlId={controlId}>
         <Col xs={11}>
@@ -65,6 +66,7 @@ const FormGroupWithCheckbox = ({
                 onChange={({ target }) => set(target.value)}
                 disabled={clear}
             />
+            {subText && <Form.Text className="text-muted">{subText}</Form.Text>}
         </Col>
         <Col xs={1} className="pl-0">
             <Form.Label>{clearLabel}&nbsp;</Form.Label>
@@ -86,9 +88,11 @@ FormGroupWithCheckbox.propTypes = {
     clearLabel: string,
     clear: bool.isRequired,
     setClear: func.isRequired,
+    subText: string,
 };
 FormGroupWithCheckbox.defaultProps = {
     clearLabel: null,
+    subText: null,
 };
 
 const CertificateManagerView = ({ hidden, writeTLSCredential, deleteTLSCredential }) => {
@@ -246,6 +250,7 @@ const CertificateManagerView = ({ hidden, writeTLSCredential, deleteTLSCredentia
                             clearLabel: 'Delete',
                             clear: clearPreSharedKey,
                             setClear: setClearPreSharedKey,
+                            subText: 'ASCII text in hexadecimal string format',
                         })}
                         {FormGroupWithCheckbox({
                             controlId: 'certMgr.pskIdentity',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-linkmonitor",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "LTE Link Monitor",
   "displayName": "LTE Link Monitor",
   "repository": {

--- a/resources/css/index.scss
+++ b/resources/css/index.scss
@@ -309,3 +309,7 @@ $disabled: #888888;
 .form-control, .input-group-addon {
     border-radius: 0px;
 }
+
+.form-label {
+    white-space: nowrap;
+}


### PR DESCRIPTION
Added subtext to input field as it caused confusion in what format PSK was required:
![image](https://user-images.githubusercontent.com/26139379/88778715-233ac400-d189-11ea-93b8-25a168129e1a.png)
