### PR TITLE
Update device filter for Thingy:91

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 1.1.5
+### Updates
+- Device filter updated for Thingy:91 #38
+
 ## Version 1.1.4
 ### Updates
 - Added help text to pre-shared key input field #37

--- a/index.jsx
+++ b/index.jsx
@@ -87,16 +87,17 @@ function pickSerialPort(serialports) {
  */
 function fixDevices(coreDevices, autoDeviceFilter) {
     const devices = coreDevices.map(device => {
-        const { serialNumber, boardVersion } = device;
-        if (serialNumber.startsWith('PCA')) {
-            const [b, s] = serialNumber.split('_');
+        const { serialNumber } = device;
+        const sn = serialNumber.toUpperCase();
+        if (sn.startsWith('PCA') || sn.startsWith('THINGY91')) {
+            const [b, s] = sn.split('_');
             return {
                 ...device,
                 boardVersion: b,
-                serialNumber: s.toUpperCase(),
+                serialNumber: s,
             };
         }
-        return { ...device, serialNumber, boardVersion };
+        return device;
     });
     if (platform !== 'dar' && autoDeviceFilter) {
         return devices;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-linkmonitor",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "LTE Link Monitor",
   "displayName": "LTE Link Monitor",
   "repository": {


### PR DESCRIPTION
Due to a change in NCS 1.3 which replaces Thingy:91's usb serialnumber from PCA20035_* to THINGY91_*.
