### PR TITLE
Remove outdated lint-init script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "webpack": "nrfconnect-scripts build-dev",
     "build": "nrfconnect-scripts build-prod",
     "nordic-publish": "nrfconnect-scripts nordic-publish",
-    "lint-init": "nrfconnect-scripts lint-init",
     "lint": "nrfconnect-scripts lint lib index.jsx test",
     "test": "jest --testResultsProcessor jest-bamboo-formatter",
     "test-watch": "jest --watch",


### PR DESCRIPTION
`lint-init` is not needed anymore. Remove the last reference to it.